### PR TITLE
openscsi: 2.0-873 -> 2.0-877

### DIFF
--- a/pkgs/os-specific/linux/open-iscsi/default.nix
+++ b/pkgs/os-specific/linux/open-iscsi/default.nix
@@ -31,6 +31,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2Plus;
     homepage = https://www.open-iscsi.com;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ cleverca22 ];
+    maintainers = with maintainers; [ cleverca22 zaninime ];
   };
 }

--- a/pkgs/os-specific/linux/open-iscsi/default.nix
+++ b/pkgs/os-specific/linux/open-iscsi/default.nix
@@ -1,26 +1,26 @@
-{ stdenv, fetchFromGitHub, automake, autoconf, libtool, gettext, utillinux, openisns, openssl, kmod }:
+{ stdenv, fetchFromGitHub, automake, autoconf, libtool, gettext, utillinux, openisns, openssl, kmod, perl, systemd, pkgconf }:
 stdenv.mkDerivation rec {
   name = "open-iscsi-${version}";
-  version = "2.0-873-${stdenv.lib.substring 0 7 src.rev}";
+  version = "2.0-877-${stdenv.lib.substring 0 7 src.rev}";
 
-  buildInputs = [ automake autoconf libtool gettext utillinux openisns.lib openssl kmod ];
-  
+  buildInputs = [ automake autoconf libtool gettext utillinux openisns.lib openssl kmod perl systemd pkgconf ];
+
   src = fetchFromGitHub {
     owner = "open-iscsi";
     repo = "open-iscsi";
-    rev = "4c1f2d90ef1c73e33d9f1e4ae9c206ffe015a8f9";
-    sha256 = "0h030zk4zih3l8z5662b3kcifdxlakbwwkz1afb7yf0cicds7va8";
+    rev = "0ec3a81158ef32da0a2866f8e2cc2ab02f2e3662";
+    sha256 = "0icwgcgldildb3blib850f7kll1knyxdylk2ic33rcddr60rxib2";
   };
-  
+
   DESTDIR = "$(out)";
-  
+
   NIX_LDFLAGS = "-lkmod";
   NIX_CFLAGS_COMPILE = "-DUSE_KMOD";
 
   preConfigure = ''
     sed -i 's|/usr|/|' Makefile
   '';
-  
+
   postInstall = ''
     cp usr/iscsistart $out/sbin/
     $out/sbin/iscsistart -v
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     description = "A high performance, transport independent, multi-platform implementation of RFC3720";
     license = licenses.gpl2Plus;
-    homepage = http://www.open-iscsi.com;
+    homepage = https://www.open-iscsi.com;
     platforms = platforms.linux;
     maintainers = with maintainers; [ cleverca22 ];
   };


### PR DESCRIPTION
###### Motivation for this change
Update openscsi, last updated on Nix in 2016. Depends on #---50771

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
cc @cleverca22
